### PR TITLE
Improved farlands

### DIFF
--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace Player
 {
-    public class PlayerMovement : NetworkBehaviour, IShipProxyRider, IWindAffected
+    public class PlayerMovement : NetworkBehaviour, IShipProxyRider
     {
         [SerializeField] private Transform physicsRoot;
         [SerializeField] private Transform visualRoot;
@@ -35,27 +35,6 @@ namespace Player
         [Header("Ship Interaction Variables")] public SyncVar<bool> isOnShipDeck;
 
         private Transform _lockedPosition;
-
-        public Vector3 WindVelocity { get; set; }
-        public Transform TransformRoot => transform;
-
-        private void OnEnable()
-        {
-            if (BoundaryWindManager.Instance != null)
-                BoundaryWindManager.Instance.Register(this);
-        }
-
-        private void OnDisable()
-        {
-            if (BoundaryWindManager.Instance != null)
-                BoundaryWindManager.Instance.Unregister(this);
-        }
-
-        private void Start()
-        {
-            if (BoundaryWindManager.Instance != null)
-                BoundaryWindManager.Instance.Register(this);
-        }
 
         private void Update()
         {
@@ -115,17 +94,21 @@ namespace Player
 
             float currentSpeed = Input.GetKey(KeyCode.LeftShift) ? sprintSpeed : moveSpeed;
 
+            Vector3 currentWindVelocity = BoundaryWindManager.Instance != null 
+                ? BoundaryWindManager.Instance.GetWindAtPosition(transform.position) 
+                : Vector3.zero;
+
             Vector3 intendedVel =
                 (transform.forward * moveInput.y + transform.right * moveInput.x) *
                 currentSpeed;
-            Vector3 targetVel = intendedVel + WindVelocity;
+            Vector3 targetVel = intendedVel + currentWindVelocity;
             
             rb.AddForce(targetVel * acceleration);
 
             var horizontal = new Vector3(rb.linearVelocity.x, 0, rb.linearVelocity.z);
             rb.AddForce(-horizontal * planarDamping);
 
-            float maxAllowedSpeed = currentSpeed + WindVelocity.magnitude;
+            float maxAllowedSpeed = currentSpeed + currentWindVelocity.magnitude;
             if (horizontal.magnitude > maxAllowedSpeed)
             {
                 Vector3 clamped = horizontal.normalized * maxAllowedSpeed;

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -1,11 +1,12 @@
 using JetBrains.Annotations;
 using PurrNet;
 using Ship;
+using Terrain;
 using UnityEngine;
 
 namespace Player
 {
-    public class PlayerMovement : NetworkBehaviour, IShipProxyRider
+    public class PlayerMovement : NetworkBehaviour, IShipProxyRider, IWindAffected
     {
         [SerializeField] private Transform physicsRoot;
         [SerializeField] private Transform visualRoot;
@@ -34,6 +35,27 @@ namespace Player
         [Header("Ship Interaction Variables")] public SyncVar<bool> isOnShipDeck;
 
         private Transform _lockedPosition;
+
+        public Vector3 WindVelocity { get; set; }
+        public Transform TransformRoot => transform;
+
+        private void OnEnable()
+        {
+            if (BoundaryWindManager.Instance != null)
+                BoundaryWindManager.Instance.Register(this);
+        }
+
+        private void OnDisable()
+        {
+            if (BoundaryWindManager.Instance != null)
+                BoundaryWindManager.Instance.Unregister(this);
+        }
+
+        private void Start()
+        {
+            if (BoundaryWindManager.Instance != null)
+                BoundaryWindManager.Instance.Register(this);
+        }
 
         private void Update()
         {
@@ -93,15 +115,22 @@ namespace Player
 
             float currentSpeed = Input.GetKey(KeyCode.LeftShift) ? sprintSpeed : moveSpeed;
 
-            Vector3 targetVel =
+            Vector3 intendedVel =
                 (transform.forward * moveInput.y + transform.right * moveInput.x) *
                 currentSpeed;
+            Vector3 targetVel = intendedVel + WindVelocity;
+            
             rb.AddForce(targetVel * acceleration);
 
             var horizontal = new Vector3(rb.linearVelocity.x, 0, rb.linearVelocity.z);
             rb.AddForce(-horizontal * planarDamping);
-            if (horizontal.magnitude > currentSpeed)
-                rb.linearVelocity = new Vector3(targetVel.x, rb.linearVelocity.y, targetVel.z);
+
+            float maxAllowedSpeed = currentSpeed + WindVelocity.magnitude;
+            if (horizontal.magnitude > maxAllowedSpeed)
+            {
+                Vector3 clamped = horizontal.normalized * maxAllowedSpeed;
+                rb.linearVelocity = new Vector3(clamped.x, rb.linearVelocity.y, clamped.z);
+            }
         }
 
         public void SetLockedPosition([CanBeNull] Transform lockedPosition)

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -94,24 +94,18 @@ namespace Player
 
             float currentSpeed = Input.GetKey(KeyCode.LeftShift) ? sprintSpeed : moveSpeed;
 
-            Vector3 currentWindVelocity = BoundaryWindManager.Instance != null 
-                ? BoundaryWindManager.Instance.GetWindAtPosition(transform.position) 
-                : Vector3.zero;
-
             Vector3 intendedVel =
                 (transform.forward * moveInput.y + transform.right * moveInput.x) *
                 currentSpeed;
-            Vector3 targetVel = intendedVel + currentWindVelocity;
             
-            rb.AddForce(targetVel * acceleration);
+            rb.AddForce(intendedVel * acceleration);
 
             var horizontal = new Vector3(rb.linearVelocity.x, 0, rb.linearVelocity.z);
             rb.AddForce(-horizontal * planarDamping);
 
-            float maxAllowedSpeed = currentSpeed + currentWindVelocity.magnitude;
-            if (horizontal.magnitude > maxAllowedSpeed)
+            if (horizontal.magnitude > currentSpeed)
             {
-                Vector3 clamped = horizontal.normalized * maxAllowedSpeed;
+                Vector3 clamped = horizontal.normalized * currentSpeed;
                 rb.linearVelocity = new Vector3(clamped.x, rb.linearVelocity.y, clamped.z);
             }
         }

--- a/Assets/Scripts/Ship/ShipControllers/ShipControllerV2.cs
+++ b/Assets/Scripts/Ship/ShipControllers/ShipControllerV2.cs
@@ -61,10 +61,13 @@ namespace Ship.ShipControllers
         private void ApplyForward()
         {
             Vector3 currentVelocity = mainShipRB.linearVelocity;
+            
+            // Subtract wind from the current velocity so we only track the ship's internal local momentum
+            Vector3 relativeVelocity = currentVelocity - WindVelocity;
 
             // Current speed along the ship's forward axis
             float currentForwardSpeed =
-                Vector3.Dot(currentVelocity, transform.right);
+                Vector3.Dot(relativeVelocity, transform.right);
 
             // Desired speed from throttle
             float targetForwardSpeed =

--- a/Assets/Scripts/Ship/ShipControllers/ShipControllerV2.cs
+++ b/Assets/Scripts/Ship/ShipControllers/ShipControllerV2.cs
@@ -1,9 +1,10 @@
 using PurrNet;
+using Terrain;
 using UnityEngine;
 
 namespace Ship.ShipControllers
 {
-    public class ShipControllerV2 : NetworkBehaviour
+    public class ShipControllerV2 : NetworkBehaviour, IWindAffected
     {
         [Header("Main Ship Variables")] public Transform mainShip;
         public Rigidbody mainShipRB;
@@ -22,6 +23,27 @@ namespace Ship.ShipControllers
         private float liftThrottle;
         private float forwardThrottle;
         private float yawThrottle;
+
+        public Vector3 WindVelocity { get; set; }
+        public Transform TransformRoot => transform;
+
+        private void OnEnable()
+        {
+            if (BoundaryWindManager.Instance != null)
+                BoundaryWindManager.Instance.Register(this);
+        }
+
+        private void OnDisable()
+        {
+            if (BoundaryWindManager.Instance != null)
+                BoundaryWindManager.Instance.Unregister(this);
+        }
+
+        private void Start()
+        {
+            if (BoundaryWindManager.Instance != null)
+                BoundaryWindManager.Instance.Register(this);
+        }
 
         private void FixedUpdate()
         {
@@ -57,6 +79,7 @@ namespace Ship.ShipControllers
 
             // Rebuild velocity
             Vector3 forwardVelocity = transform.right * newForwardSpeed;
+            forwardVelocity += WindVelocity;
 
             mainShipRB.linearVelocity = new Vector3(
                 forwardVelocity.x,

--- a/Assets/Scripts/Ship/ShipControllers/ShipControllerV2.cs
+++ b/Assets/Scripts/Ship/ShipControllers/ShipControllerV2.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Ship.ShipControllers
 {
-    public class ShipControllerV2 : NetworkBehaviour, IWindAffected
+    public class ShipControllerV2 : NetworkBehaviour
     {
         [Header("Main Ship Variables")] public Transform mainShip;
         public Rigidbody mainShipRB;
@@ -24,29 +24,10 @@ namespace Ship.ShipControllers
         private float forwardThrottle;
         private float yawThrottle;
 
-        public Vector3 WindVelocity { get; set; }
-        public Transform TransformRoot => transform;
-
-        private void OnEnable()
-        {
-            if (BoundaryWindManager.Instance != null)
-                BoundaryWindManager.Instance.Register(this);
-        }
-
-        private void OnDisable()
-        {
-            if (BoundaryWindManager.Instance != null)
-                BoundaryWindManager.Instance.Unregister(this);
-        }
-
-        private void Start()
-        {
-            if (BoundaryWindManager.Instance != null)
-                BoundaryWindManager.Instance.Register(this);
-        }
-
         private void FixedUpdate()
         {
+            if (!isServer) return;
+
             ApplyLift();
             ApplyForward();
             ApplyYaw();
@@ -62,8 +43,12 @@ namespace Ship.ShipControllers
         {
             Vector3 currentVelocity = mainShipRB.linearVelocity;
             
+            Vector3 currentWindVelocity = BoundaryWindManager.Instance != null 
+                ? BoundaryWindManager.Instance.GetWindAtPosition(transform.position) 
+                : Vector3.zero;
+            
             // Subtract wind from the current velocity so we only track the ship's internal local momentum
-            Vector3 relativeVelocity = currentVelocity - WindVelocity;
+            Vector3 relativeVelocity = currentVelocity - currentWindVelocity;
 
             // Current speed along the ship's forward axis
             float currentForwardSpeed =
@@ -82,7 +67,7 @@ namespace Ship.ShipControllers
 
             // Rebuild velocity
             Vector3 forwardVelocity = transform.right * newForwardSpeed;
-            forwardVelocity += WindVelocity;
+            forwardVelocity += currentWindVelocity;
 
             mainShipRB.linearVelocity = new Vector3(
                 forwardVelocity.x,

--- a/Assets/Scripts/terrain/BoundaryWindManager.cs
+++ b/Assets/Scripts/terrain/BoundaryWindManager.cs
@@ -12,70 +12,42 @@ namespace Terrain
         public float maxClockwiseWindSpeed = 5f;
 
         private WorldGenerator _worldGenerator;
-        private readonly List<IWindAffected> _windReceivers = new List<IWindAffected>();
 
         private void Awake()
         {
-            if (Instance == null)
-            {
-                Instance = this;
-            }
+            if (Instance == null) Instance = this;
             _worldGenerator = GetComponent<WorldGenerator>();
         }
 
-        public void Register(IWindAffected receiver)
+        public Vector3 GetWindAtPosition(Vector3 position)
         {
-            if (!_windReceivers.Contains(receiver))
-            {
-                _windReceivers.Add(receiver);
-            }
-        }
-
-        public void Unregister(IWindAffected receiver)
-        {
-            _windReceivers.Remove(receiver);
-        }
-
-        private void FixedUpdate()
-        {
-            if (_worldGenerator == null) return;
+            if (_worldGenerator == null) return Vector3.zero;
 
             float innerRadius = _worldGenerator.innerRadius;
             float outerRadius = innerRadius + _worldGenerator.emptyRingWidth;
 
-            for (int i = 0; i < _windReceivers.Count; i++)
+            Vector3 pos2D = new Vector3(position.x, 0, position.z);
+            float dist = pos2D.magnitude;
+
+            if (dist > innerRadius)
             {
-                var receiver = _windReceivers[i];
-                if (receiver == null || receiver.TransformRoot == null) continue;
+                // Scale from 0 at inner radius to 1 at outer radius
+                float tFactor = Mathf.Clamp01((dist - innerRadius) / (outerRadius - innerRadius));
+                
+                // Inward wind scales quadratically (to give some space for clockwise movement)
+                float inwardStrength = tFactor * tFactor;
+                
+                // Clockwise wind ramps up linearly
+                float clockwiseStrength = tFactor;
 
-                Vector3 pos = receiver.TransformRoot.position;
-                Vector3 pos2D = new Vector3(pos.x, 0, pos.z);
-                float dist = pos2D.magnitude;
+                Vector3 inwardDir = -pos2D.normalized;
+                Vector3 clockwiseDir = Vector3.Cross(Vector3.up, pos2D.normalized);
 
-                if (dist > innerRadius)
-                {
-                    // Scale from 0 at inner radius to 1 at outer radius
-                    float tFactor = Mathf.Clamp01((dist - innerRadius) / (outerRadius - innerRadius));
-                    
-                    // Inward wind scales quadratically (to give some space for clockwise movement)
-                    float inwardStrength = tFactor * tFactor;
-                    
-                    // Clockwise wind ramps up linearly
-                    float clockwiseStrength = tFactor;
-
-                    Vector3 inwardDir = -pos2D.normalized;
-                    Vector3 clockwiseDir = Vector3.Cross(Vector3.up, pos2D.normalized);
-
-                    Vector3 wind = inwardDir * (maxInwardWindSpeed * inwardStrength) 
-                                 + clockwiseDir * (maxClockwiseWindSpeed * clockwiseStrength);
-
-                    receiver.WindVelocity = wind;
-                }
-                else
-                {
-                    receiver.WindVelocity = Vector3.zero;
-                }
+                return inwardDir * (maxInwardWindSpeed * inwardStrength) 
+                     + clockwiseDir * (maxClockwiseWindSpeed * clockwiseStrength);
             }
+            
+            return Vector3.zero;
         }
     }
 }

--- a/Assets/Scripts/terrain/BoundaryWindManager.cs
+++ b/Assets/Scripts/terrain/BoundaryWindManager.cs
@@ -9,7 +9,7 @@ namespace Terrain
         public static BoundaryWindManager Instance { get; private set; }
 
         public float maxInwardWindSpeed = 40f;
-        public float maxClockwiseWindSpeed = 3f;
+        public float maxClockwiseWindSpeed = 5f;
 
         private WorldGenerator _worldGenerator;
         private readonly List<IWindAffected> _windReceivers = new List<IWindAffected>();

--- a/Assets/Scripts/terrain/BoundaryWindManager.cs
+++ b/Assets/Scripts/terrain/BoundaryWindManager.cs
@@ -8,8 +8,8 @@ namespace Terrain
     {
         public static BoundaryWindManager Instance { get; private set; }
 
-        public float maxInwardWindSpeed = 100f;
-        public float maxClockwiseWindSpeed = 50f;
+        public float maxInwardWindSpeed = 40f;
+        public float maxClockwiseWindSpeed = 3f;
 
         private WorldGenerator _worldGenerator;
         private readonly List<IWindAffected> _windReceivers = new List<IWindAffected>();
@@ -55,20 +55,19 @@ namespace Terrain
                 if (dist > innerRadius)
                 {
                     // Scale from 0 at inner radius to 1 at outer radius
-                    // Using square curve so it starts weak and becomes very strong at the end
                     float tFactor = Mathf.Clamp01((dist - innerRadius) / (outerRadius - innerRadius));
-                    float strengthFactor = tFactor * tFactor;
+                    
+                    // Inward wind scales quadratically (to give some space for clockwise movement)
+                    float inwardStrength = tFactor * tFactor;
+                    
+                    // Clockwise wind ramps up linearly
+                    float clockwiseStrength = tFactor;
 
                     Vector3 inwardDir = -pos2D.normalized;
                     Vector3 clockwiseDir = Vector3.Cross(Vector3.up, pos2D.normalized);
 
-                    Vector3 wind = (inwardDir * maxInwardWindSpeed + clockwiseDir * maxClockwiseWindSpeed) * strengthFactor;
-
-                    // Absolute barrier beyond outer radius
-                    if (dist > outerRadius)
-                    {
-                        wind += inwardDir * (dist - outerRadius) * 200f;
-                    }
+                    Vector3 wind = inwardDir * (maxInwardWindSpeed * inwardStrength) 
+                                 + clockwiseDir * (maxClockwiseWindSpeed * clockwiseStrength);
 
                     receiver.WindVelocity = wind;
                 }

--- a/Assets/Scripts/terrain/BoundaryWindManager.cs
+++ b/Assets/Scripts/terrain/BoundaryWindManager.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Terrain
+{
+    [RequireComponent(typeof(WorldGenerator))]
+    public class BoundaryWindManager : MonoBehaviour
+    {
+        public static BoundaryWindManager Instance { get; private set; }
+
+        public float maxInwardWindSpeed = 100f;
+        public float maxClockwiseWindSpeed = 50f;
+
+        private WorldGenerator _worldGenerator;
+        private readonly List<IWindAffected> _windReceivers = new List<IWindAffected>();
+
+        private void Awake()
+        {
+            if (Instance == null)
+            {
+                Instance = this;
+            }
+            _worldGenerator = GetComponent<WorldGenerator>();
+        }
+
+        public void Register(IWindAffected receiver)
+        {
+            if (!_windReceivers.Contains(receiver))
+            {
+                _windReceivers.Add(receiver);
+            }
+        }
+
+        public void Unregister(IWindAffected receiver)
+        {
+            _windReceivers.Remove(receiver);
+        }
+
+        private void FixedUpdate()
+        {
+            if (_worldGenerator == null) return;
+
+            float innerRadius = _worldGenerator.innerRadius;
+            float outerRadius = innerRadius + _worldGenerator.emptyRingWidth;
+
+            for (int i = 0; i < _windReceivers.Count; i++)
+            {
+                var receiver = _windReceivers[i];
+                if (receiver == null || receiver.TransformRoot == null) continue;
+
+                Vector3 pos = receiver.TransformRoot.position;
+                Vector3 pos2D = new Vector3(pos.x, 0, pos.z);
+                float dist = pos2D.magnitude;
+
+                if (dist > innerRadius)
+                {
+                    // Scale from 0 at inner radius to 1 at outer radius
+                    // Using square curve so it starts weak and becomes very strong at the end
+                    float tFactor = Mathf.Clamp01((dist - innerRadius) / (outerRadius - innerRadius));
+                    float strengthFactor = tFactor * tFactor;
+
+                    Vector3 inwardDir = -pos2D.normalized;
+                    Vector3 clockwiseDir = Vector3.Cross(Vector3.up, pos2D.normalized);
+
+                    Vector3 wind = (inwardDir * maxInwardWindSpeed + clockwiseDir * maxClockwiseWindSpeed) * strengthFactor;
+
+                    // Absolute barrier beyond outer radius
+                    if (dist > outerRadius)
+                    {
+                        wind += inwardDir * (dist - outerRadius) * 200f;
+                    }
+
+                    receiver.WindVelocity = wind;
+                }
+                else
+                {
+                    receiver.WindVelocity = Vector3.zero;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/terrain/BoundaryWindManager.cs.meta
+++ b/Assets/Scripts/terrain/BoundaryWindManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ef0bd67f185c14d6996e7c52aa1a3e0d

--- a/Assets/Scripts/terrain/FarlandsVisibilityManager.cs
+++ b/Assets/Scripts/terrain/FarlandsVisibilityManager.cs
@@ -6,15 +6,29 @@ namespace Terrain
     public class FarlandsVisibilityManager : MonoBehaviour
     {
         public float visibilityThresholdRadius = 400f; 
-        private readonly List<GameObject> _farlandsIslands = new List<GameObject>();
-        private bool _isCurrentlyVisible = true;
+        public float randomOffsetRange = 100f; // Each island will pop in progressively slower
+
+        private class IslandData
+        {
+            public GameObject Island;
+            public float RandomThresholdOffset;
+            public bool IsVisible;
+        }
+
+        private readonly List<IslandData> _farlandsIslands = new List<IslandData>();
         private Camera _mainCamera;
 
         public void RegisterFarlandsIsland(GameObject island)
         {
-            _farlandsIslands.Add(island);
-            // Match the current state instantly
-            island.SetActive(_isCurrentlyVisible);
+            var data = new IslandData
+            {
+                Island = island,
+                RandomThresholdOffset = Random.Range(0f, randomOffsetRange),
+                IsVisible = false // Force update check to sync correctly
+            };
+            
+            _farlandsIslands.Add(data);
+            island.SetActive(false);
         }
 
         private void Start()
@@ -25,8 +39,8 @@ namespace Terrain
 
         private void Update()
         {
-            // Update twice a second for performance since it's just a distance check
-            if (Time.frameCount % 30 == 0)
+            // Checking periodically to stagger the pop in calculations
+            if (Time.frameCount % 10 == 0)
             {
                 UpdateVisibility();
             }
@@ -42,18 +56,20 @@ namespace Terrain
 
             Vector3 camPos = _mainCamera.transform.position;
             camPos.y = 0; // measure flat 2D distance to center of the world
-            
-            bool shouldBeVisible = camPos.magnitude > visibilityThresholdRadius;
+            float distSquared = camPos.sqrMagnitude;
+            float currentDist = Mathf.Sqrt(distSquared);
 
-            if (shouldBeVisible != _isCurrentlyVisible)
+            for (int i = 0; i < _farlandsIslands.Count; i++)
             {
-                _isCurrentlyVisible = shouldBeVisible;
-                for (int i = 0; i < _farlandsIslands.Count; i++)
+                var data = _farlandsIslands[i];
+                if (data.Island == null) continue;
+
+                bool shouldBeVisible = currentDist > (visibilityThresholdRadius + data.RandomThresholdOffset);
+
+                if (shouldBeVisible != data.IsVisible)
                 {
-                    if (_farlandsIslands[i] != null)
-                    {
-                        _farlandsIslands[i].SetActive(_isCurrentlyVisible);
-                    }
+                    data.IsVisible = shouldBeVisible;
+                    data.Island.SetActive(data.IsVisible);
                 }
             }
         }

--- a/Assets/Scripts/terrain/FarlandsVisibilityManager.cs
+++ b/Assets/Scripts/terrain/FarlandsVisibilityManager.cs
@@ -6,12 +6,15 @@ namespace Terrain
     public class FarlandsVisibilityManager : MonoBehaviour
     {
         public float visibilityThresholdRadius = 400f; 
-        public float randomOffsetRange = 100f; // Each island will pop in progressively slower
+        public float randomOffsetRange = 100f; // Each island threshold offset
+        public float fadeDistanceBand = 75f; // Distance over which the island rises
+        public float riseDepth = 250f; // How far below standard elevation it starts
 
         private class IslandData
         {
             public GameObject Island;
             public float RandomThresholdOffset;
+            public float OriginalY;
             public bool IsVisible;
         }
 
@@ -24,11 +27,15 @@ namespace Terrain
             {
                 Island = island,
                 RandomThresholdOffset = Random.Range(0f, randomOffsetRange),
+                OriginalY = island.transform.position.y,
                 IsVisible = false // Force update check to sync correctly
             };
             
             _farlandsIslands.Add(data);
             island.SetActive(false);
+            
+            // Set it to its hidden depth right away
+            island.transform.position = new Vector3(island.transform.position.x, data.OriginalY - riseDepth, island.transform.position.z);
         }
 
         private void Start()
@@ -39,11 +46,7 @@ namespace Terrain
 
         private void Update()
         {
-            // Checking periodically to stagger the pop in calculations
-            if (Time.frameCount % 10 == 0)
-            {
-                UpdateVisibility();
-            }
+            UpdateVisibility();
         }
 
         private void UpdateVisibility()
@@ -56,20 +59,47 @@ namespace Terrain
 
             Vector3 camPos = _mainCamera.transform.position;
             camPos.y = 0; // measure flat 2D distance to center of the world
-            float distSquared = camPos.sqrMagnitude;
-            float currentDist = Mathf.Sqrt(distSquared);
+            float currentDist = camPos.magnitude;
 
             for (int i = 0; i < _farlandsIslands.Count; i++)
             {
                 var data = _farlandsIslands[i];
                 if (data.Island == null) continue;
 
-                bool shouldBeVisible = currentDist > (visibilityThresholdRadius + data.RandomThresholdOffset);
-
-                if (shouldBeVisible != data.IsVisible)
+                float islandBaseThreshold = visibilityThresholdRadius + data.RandomThresholdOffset;
+                float islandFullyVisibleTarget = islandBaseThreshold + fadeDistanceBand;
+                
+                // If it is entirely too far away
+                if (currentDist < islandBaseThreshold)
                 {
-                    data.IsVisible = shouldBeVisible;
-                    data.Island.SetActive(data.IsVisible);
+                    if (data.IsVisible)
+                    {
+                        data.IsVisible = false;
+                        data.Island.SetActive(false);
+                    }
+                }
+                else
+                {
+                    if (!data.IsVisible)
+                    {
+                        data.IsVisible = true;
+                        data.Island.SetActive(true);
+                    }
+
+                    // Calculate depth
+                    float depthLerp = Mathf.InverseLerp(islandBaseThreshold, islandFullyVisibleTarget, currentDist);
+                    // Smoothstep for prettier rise
+                    depthLerp = Mathf.SmoothStep(0f, 1f, depthLerp);
+                    
+                    float targetY = Mathf.Lerp(data.OriginalY - riseDepth, data.OriginalY, depthLerp);
+                    
+                    Vector3 islandPos = data.Island.transform.position;
+                    // Only update if it actually moved significantly to save physics recalculation ticks if fully rested
+                    if (Mathf.Abs(islandPos.y - targetY) > 0.01f)
+                    {
+                        islandPos.y = targetY;
+                        data.Island.transform.position = islandPos;
+                    }
                 }
             }
         }

--- a/Assets/Scripts/terrain/FarlandsVisibilityManager.cs
+++ b/Assets/Scripts/terrain/FarlandsVisibilityManager.cs
@@ -58,19 +58,22 @@ namespace Terrain
             }
 
             Vector3 camPos = _mainCamera.transform.position;
-            camPos.y = 0; // measure flat 2D distance to center of the world
-            float currentDist = camPos.magnitude;
+            camPos.y = 0; // measure flat 2D distance
 
+            // We reuse visibilityThresholdRadius (~350m) as the actual detection sphere around the camera.
             for (int i = 0; i < _farlandsIslands.Count; i++)
             {
                 var data = _farlandsIslands[i];
                 if (data.Island == null) continue;
 
+                Vector3 islandPos2D = new Vector3(data.Island.transform.position.x, 0, data.Island.transform.position.z);
+                float distToIsland = Vector3.Distance(camPos, islandPos2D);
+
                 float islandBaseThreshold = visibilityThresholdRadius + data.RandomThresholdOffset;
-                float islandFullyVisibleTarget = islandBaseThreshold + fadeDistanceBand;
+                float islandFullyVisibleTarget = islandBaseThreshold - fadeDistanceBand; // Closer distance = fully visible
                 
                 // If it is entirely too far away
-                if (currentDist < islandBaseThreshold)
+                if (distToIsland > islandBaseThreshold)
                 {
                     if (data.IsVisible)
                     {
@@ -87,7 +90,7 @@ namespace Terrain
                     }
 
                     // Calculate depth
-                    float depthLerp = Mathf.InverseLerp(islandBaseThreshold, islandFullyVisibleTarget, currentDist);
+                    float depthLerp = Mathf.InverseLerp(islandBaseThreshold, islandFullyVisibleTarget, distToIsland);
                     // Smoothstep for prettier rise
                     depthLerp = Mathf.SmoothStep(0f, 1f, depthLerp);
                     

--- a/Assets/Scripts/terrain/FarlandsVisibilityManager.cs
+++ b/Assets/Scripts/terrain/FarlandsVisibilityManager.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Terrain
+{
+    public class FarlandsVisibilityManager : MonoBehaviour
+    {
+        public float visibilityThresholdRadius = 400f; 
+        private readonly List<GameObject> _farlandsIslands = new List<GameObject>();
+        private bool _isCurrentlyVisible = true;
+        private Camera _mainCamera;
+
+        public void RegisterFarlandsIsland(GameObject island)
+        {
+            _farlandsIslands.Add(island);
+            // Match the current state instantly
+            island.SetActive(_isCurrentlyVisible);
+        }
+
+        private void Start()
+        {
+            _mainCamera = Camera.main;
+            UpdateVisibility();
+        }
+
+        private void Update()
+        {
+            // Update twice a second for performance since it's just a distance check
+            if (Time.frameCount % 30 == 0)
+            {
+                UpdateVisibility();
+            }
+        }
+
+        private void UpdateVisibility()
+        {
+            if (_mainCamera == null)
+            {
+                _mainCamera = Camera.main;
+                if (_mainCamera == null) return;
+            }
+
+            Vector3 camPos = _mainCamera.transform.position;
+            camPos.y = 0; // measure flat 2D distance to center of the world
+            
+            bool shouldBeVisible = camPos.magnitude > visibilityThresholdRadius;
+
+            if (shouldBeVisible != _isCurrentlyVisible)
+            {
+                _isCurrentlyVisible = shouldBeVisible;
+                for (int i = 0; i < _farlandsIslands.Count; i++)
+                {
+                    if (_farlandsIslands[i] != null)
+                    {
+                        _farlandsIslands[i].SetActive(_isCurrentlyVisible);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/terrain/FarlandsVisibilityManager.cs.meta
+++ b/Assets/Scripts/terrain/FarlandsVisibilityManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 812a0925c514d4e6a84f93e92b032439

--- a/Assets/Scripts/terrain/IWindAffected.cs
+++ b/Assets/Scripts/terrain/IWindAffected.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+namespace Terrain
+{
+    public interface IWindAffected
+    {
+        Vector3 WindVelocity { get; set; }
+        Transform TransformRoot { get; }
+    }
+}

--- a/Assets/Scripts/terrain/IWindAffected.cs.meta
+++ b/Assets/Scripts/terrain/IWindAffected.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1de9610057bcc4fe8a0559015092858c

--- a/Assets/Scripts/terrain/WorldGenerator.cs
+++ b/Assets/Scripts/terrain/WorldGenerator.cs
@@ -10,7 +10,7 @@ namespace Terrain
         public float innerRadius = 500f;
 
         [Tooltip("Width of the empty ring outside the inner world.")]
-        public float emptyRingWidth = 100f;
+        public float emptyRingWidth = 200f;
 
         [Tooltip("Width of the outermost ring where specific islands spawn.")]
         public float outerRingWidth = 200f;

--- a/Assets/Scripts/terrain/WorldGenerator.cs
+++ b/Assets/Scripts/terrain/WorldGenerator.cs
@@ -49,12 +49,28 @@ namespace Terrain
 
         private bool startingIslandSet = false;
 
+        private FarlandsVisibilityManager _visibilityManager;
+
         // Trigger worldgen on start
         private void Start()
         {
             if (gameObject.GetComponent<BoundaryWindManager>() == null)
             {
                 gameObject.AddComponent<BoundaryWindManager>();
+            }
+            if (gameObject.GetComponent<FarlandsVisibilityManager>() == null)
+            {
+                _visibilityManager = gameObject.AddComponent<FarlandsVisibilityManager>();
+            }
+            else
+            {
+                _visibilityManager = gameObject.GetComponent<FarlandsVisibilityManager>();
+            }
+            
+            // Set visibility threshold to 150m before the inner radius
+            if (_visibilityManager != null)
+            {
+                _visibilityManager.visibilityThresholdRadius = Mathf.Max(0, innerRadius - 150f);
             }
 
             GenerateWorld();
@@ -149,7 +165,16 @@ namespace Terrain
 
             if (!startingIslandSet) startingIslandSet = true;
             TerrainNoiseData t = data.terrainData;
-            // print($"[{data.prefab.name}_{position}] seed={t.seed} scale={t.noiseScale:F2} persistence={t.persistence:F2} lacunarity={t.lacunarity:F2} heightMult={t.heightMeshMultiplier:F2} octaves={t.octaves} offset={t.offset}");
+            
+            if (_visibilityManager != null)
+            {
+                // If it's placed out in the empty gap or outer farlands
+                if (new Vector3(position.x, 0, position.z).magnitude > innerRadius)
+                {
+                    _visibilityManager.RegisterFarlandsIsland(instance);
+                }
+            }
+            
             // Record placement
             placedIslands.Add(new PlacedIsland
             {

--- a/Assets/Scripts/terrain/WorldGenerator.cs
+++ b/Assets/Scripts/terrain/WorldGenerator.cs
@@ -52,6 +52,11 @@ namespace Terrain
         // Trigger worldgen on start
         private void Start()
         {
+            if (gameObject.GetComponent<BoundaryWindManager>() == null)
+            {
+                gameObject.AddComponent<BoundaryWindManager>();
+            }
+
             GenerateWorld();
         }
 


### PR DESCRIPTION
Make farlands into actual world border.  They now start hidden and only start rendering in once players approach world edge. They appear by floating up from below.

Wind current between world edge and farlands acts as soft border & there is slight clockwise component to wind so the gap can be used for faster travel around the edge